### PR TITLE
Compatibility with case sensitive file systems.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
 	getParser: function(encoding) {
 		return Q.Promise(function(resolve, reject) {
 			try {
-				var filePath = path.join(__dirname, 'parser', encoding);
+				var filePath = path.join(__dirname, 'parser', encoding.toLowerCase());
 
 				var p = require(filePath);
 


### PR DESCRIPTION
At the moment the examples in the documents suggest using getParser like this: epc.getParser('SGTIN').

However this will fail on case sensitive file systems. Since all parsers have lowercase folder names I propose adding this PR that converts the input to lowercase before looking up the parser.